### PR TITLE
More specification accurate checks?

### DIFF
--- a/is-generator.js
+++ b/is-generator.js
@@ -11,9 +11,9 @@ module.exports.fn = isGeneratorFunction
  * @return {Boolean}
  */
 function isGenerator (obj) {
-  return obj &&
-    typeof obj.next === 'function' &&
-    typeof obj.throw === 'function'
+  return typeof obj == "object" && 
+    obj !== null && 
+    obj.constructor instanceof GeneratorFunction;
 }
 
 /**
@@ -23,7 +23,5 @@ function isGenerator (obj) {
  * @return {Boolean}
  */
 function isGeneratorFunction (fn) {
-  return typeof fn === 'function' &&
-    fn.constructor &&
-    fn.constructor.name === 'GeneratorFunction'
+  return fn instanceof GeneratorFunction
 }


### PR DESCRIPTION
I read the [ECMA tc-39 spec on the `GeneratorFunction` constructor](https://tc39.es/ecma262/#sec-generatorfunction-constructor), and I believe that the following changes utilizing constructor of [`GeneratorFunction`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction) would be better. 

That being said... I don't know if this would break dependent developer's code on update. :/

I avoided optional chaining intentionally for backwards-compatibility.